### PR TITLE
Added useBooleanFormField to the docs

### DIFF
--- a/example/src/domain/machinery/Form.js
+++ b/example/src/domain/machinery/Form.js
@@ -68,7 +68,6 @@ export function FormObjectField({ field, render }) {
     </div>
   )
 }
-
 export function FormFieldValue({ field, render }) {
   console.log(`[${field.name}] render value field`)
   const value = useFormFieldValue(field)

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ _See the example for use cases_
   - [useForm](#useForm)
   - [useFormField](#useFormField)
   - [useNumberFormField](#useNumberFormField)
+  - [useBooleanFormField](#useBooleanFormField)
   - [useArrayFormField](#useArrayFormField)
   - [useObjectFormField](#useObjectFormField)
   - [useFormFieldSnapshot](#useFormFieldSnapshot)
@@ -190,6 +191,10 @@ const {
 #### useNumberFormField
 
 Specialized version of [`useFormField`](#useFormField) that converts the value to a a number if possible.
+
+#### useBooleanFormField
+
+Specialized version of [`useFormField`](#useFormField) that reports the checked state of the input as value.
 
 #### useArrayFormField
 

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ Specialized version of [`useFormField`](#useFormField) that converts the value t
 
 #### useBooleanFormField
 
-Specialized version of [`useFormField`](#useFormField) that reports the checked state of the input as value.
+Specialized version of [`useFormField`](#useFormField) that uses the checked state of the event target as value.
 
 #### useArrayFormField
 


### PR DESCRIPTION
@EECOLOR Maybe we should rename `useBooleanFormField` to `useCheckableFormField` since it really only works if the connected input has a checked property?